### PR TITLE
メッセージ投稿機能の非同期化

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,0 +1,6 @@
+$(function() {
+  $("#new_message").submit(function(e) {
+    e.preventDefault(); // デフォルトのイベント(送信)を止める
+    var formData = new FormData(this);
+  });
+});

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -26,8 +26,7 @@ $(function() {
   }
 
   $("#new_message").submit(function(e) {
-    e.preventDefault(); // デフォルトのイベント(送信)を止める
-
+    e.preventDefault();
     var formData = new FormData(this);
     var url = $(this).attr("action"); // リクエスト送信先のURLを取得
 
@@ -46,7 +45,10 @@ $(function() {
         scrollBottom(target);
       })
       .fail(function(data) {
-        alert("エラーが発生したためメッセージは送信できませんでした。");
+        alert("メッセージを入力してください。");
+      })
+      .always(function(data) {
+        $(".chat_form__message__button").prop("disabled", false); // ボタンを押下可能にする
       });
   });
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -20,6 +20,11 @@ $(function() {
     return html;
   }
 
+  function scrollBottom(target) {
+    var scrollHeight = $(target)[0].scrollHeight;
+    $(target).animate({ scrollTop: scrollHeight }, 1000);
+  }
+
   $("#new_message").submit(function(e) {
     e.preventDefault(); // デフォルトのイベント(送信)を止める
 
@@ -36,7 +41,9 @@ $(function() {
     })
       .done(function(data) {
         var html = buildHTML(data);
-        $(".chat_messages").append(html);
+        var target = ".chat_messages";
+        $(target).append(html);
+        scrollBottom(target);
       })
       .fail(function(data) {
         alert("エラーが発生したためメッセージは送信できませんでした。");

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,4 +1,25 @@
 $(function() {
+  function buildHTML(message) {
+    var image = message.image ? `<img src= ${message.image}>` : "";
+    var html = `<div class="chat_message">
+                  <div class="chat_message__header">
+                    <p class="chat_message__header__name">
+                      ${message.user_name}
+                    </p>
+                    <p class="chat_message__header__date">
+                    ${message.date}
+                    </p>
+                  </div>
+                  <div class="chat_message__text">
+                    <p>
+                      ${message.body}
+                    </p>
+                    ${image}
+                  </div>
+                </div>`;
+    return html;
+  }
+
   $("#new_message").submit(function(e) {
     e.preventDefault(); // デフォルトのイベント(送信)を止める
 
@@ -12,6 +33,13 @@ $(function() {
       dataType: "json",
       processData: false,
       contentType: false
-    });
+    })
+      .done(function(data) {
+        var html = buildHTML(data);
+        $(".chat_messages").append(html);
+      })
+      .fail(function(data) {
+        alert("エラーが発生したためメッセージは送信できませんでした。");
+      });
   });
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,7 +1,9 @@
 $(function() {
-  function buildHTML(message) {
-    var image = message.image ? `<img src= ${message.image}>` : "";
-    var html = `<div class="chat_message">
+$(document).on("turbolinks:load", function() {
+  $(function() {
+    function buildHTML(message) {
+      var image = message.image ? `<img src= ${message.image}>` : "";
+      var html = `<div class="chat_message">
                   <div class="chat_message__header">
                     <p class="chat_message__header__name">
                       ${message.user_name}
@@ -17,44 +19,45 @@ $(function() {
                     ${image}
                   </div>
                 </div>`;
-    return html;
-  }
+      return html;
+    }
 
-  function scrollBottom(target) {
-    var scrollHeight = $(target)[0].scrollHeight;
-    $(target).animate({ scrollTop: scrollHeight }, 1000);
-  }
+    function scrollBottom(target) {
+      var scrollHeight = $(target)[0].scrollHeight;
+      $(target).animate({ scrollTop: scrollHeight }, 1000);
+    }
 
-  function clearForm() {
-    $("#message_body").val(""); // 入力欄を空にする
-    $('input[type="file"]').val(null); // 選択中の画像を削除する
-  }
+    function clearForm() {
+      $("#message_body").val(""); // 入力欄を空にする
+      $('input[type="file"]').val(null); // 選択中の画像を削除する
+    }
 
-  $("#new_message").submit(function(e) {
-    e.preventDefault();
-    var formData = new FormData(this);
-    var url = $(this).attr("action"); // リクエスト送信先のURLを取得
+    $("#new_message").submit(function(e) {
+      e.preventDefault();
+      var formData = new FormData(this);
+      var url = $(this).attr("action"); // リクエスト送信先のURLを取得
 
-    $.ajax({
-      url: url,
-      type: "POST",
-      data: formData,
-      dataType: "json",
-      processData: false,
-      contentType: false
-    })
-      .done(function(data) {
-        var html = buildHTML(data);
-        var target = ".chat_messages";
-        $(target).append(html);
-        scrollBottom(target);
-        clearForm();
+      $.ajax({
+        url: url,
+        type: "POST",
+        data: formData,
+        dataType: "json",
+        processData: false,
+        contentType: false
       })
-      .fail(function(data) {
-        alert("メッセージを入力してください。");
-      })
-      .always(function(data) {
-        $(".chat_form__message__button").prop("disabled", false); // ボタンを押下可能にする
-      });
+        .done(function(data) {
+          var html = buildHTML(data);
+          var target = ".chat_messages";
+          $(target).append(html);
+          scrollBottom(target);
+          clearForm();
+        })
+        .fail(function(data) {
+          alert("メッセージを入力してください。");
+        })
+        .always(function(data) {
+          $(".chat_form__message__button").prop("disabled", false); // ボタンを押下可能にする
+        });
+    });
   });
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -26,11 +26,6 @@ $(document).on("turbolinks:load", function() {
       $(target).animate({ scrollTop: scrollHeight }, 1000);
     }
 
-    function clearForm() {
-      $("#message_body").val(""); // 入力欄を空にする
-      $('input[type="file"]').val(null); // 選択中の画像を削除する
-    }
-
     $("#new_message").submit(function(e) {
       e.preventDefault();
       var formData = new FormData(this);
@@ -49,7 +44,7 @@ $(document).on("turbolinks:load", function() {
           var target = ".chat_messages";
           $(target).append(html);
           scrollBottom(target);
-          clearForm();
+          $("#new_message")[0].reset(); // 入力欄を空にする
         })
         .fail(function(data) {
           alert("メッセージを入力してください。");

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,4 +1,3 @@
-$(function() {
 $(document).on("turbolinks:load", function() {
   $(function() {
     function buildHTML(message) {

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,6 +1,17 @@
 $(function() {
   $("#new_message").submit(function(e) {
     e.preventDefault(); // デフォルトのイベント(送信)を止める
+
     var formData = new FormData(this);
+    var url = $(this).attr("action"); // リクエスト送信先のURLを取得
+
+    $.ajax({
+      url: url,
+      type: "POST",
+      data: formData,
+      dataType: "json",
+      processData: false,
+      contentType: false
+    });
   });
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -25,6 +25,11 @@ $(function() {
     $(target).animate({ scrollTop: scrollHeight }, 1000);
   }
 
+  function clearForm() {
+    $("#message_body").val(""); // 入力欄を空にする
+    $('input[type="file"]').val(null); // 選択中の画像を削除する
+  }
+
   $("#new_message").submit(function(e) {
     e.preventDefault();
     var formData = new FormData(this);
@@ -43,6 +48,7 @@ $(function() {
         var target = ".chat_messages";
         $(target).append(html);
         scrollBottom(target);
+        clearForm();
       })
       .fail(function(data) {
         alert("メッセージを入力してください。");

--- a/app/assets/stylesheets/modules/_chat_messages.scss
+++ b/app/assets/stylesheets/modules/_chat_messages.scss
@@ -26,8 +26,8 @@
     color: $color-darkGray;
     margin-bottom: 10px;
     font-size: 14px;
-    &__image {
-      width: 300px;
-    }
+  }
+  &__text img {
+    width: 300px;
   }
 }

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -11,20 +11,13 @@ class MessagesController < ApplicationController
     @message = @group.messages.new(message_params)
     if @message.save
       respond_to do |format|
-       format.html { redirect_to group_messages_path, notice: 'メッセージが送信されました' }
+       format.html
        format.json
      end
     else
-      flash.now[:alert] = 'メッセージを入力してください。'
+      # flash.now[:alert] = 'メッセージを入力してください。'
       render :index
     end
-
-    # if @message.save
-    #   redirect_to group_messages_path, notice: 'メッセージが送信されました'
-    # else
-    #   flash.now[:alert] = 'メッセージを入力してください。'
-    #   render :index
-    # end
   end
 
   private

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -10,11 +10,21 @@ class MessagesController < ApplicationController
   def create
     @message = @group.messages.new(message_params)
     if @message.save
-      redirect_to group_messages_path, notice: 'メッセージが送信されました'
+      respond_to do |format|
+       format.html { redirect_to group_messages_path, notice: 'メッセージが送信されました' }
+       format.json
+     end
     else
       flash.now[:alert] = 'メッセージを入力してください。'
       render :index
     end
+
+    # if @message.save
+    #   redirect_to group_messages_path, notice: 'メッセージが送信されました'
+    # else
+    #   flash.now[:alert] = 'メッセージを入力してください。'
+    #   render :index
+    # end
   end
 
   private

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -15,7 +15,7 @@ class MessagesController < ApplicationController
        format.json
      end
     else
-      # flash.now[:alert] = 'メッセージを入力してください。'
+      flash.now[:alert] = 'メッセージを入力してください。'
       render :index
     end
   end

--- a/app/views/messages/_chat_form.html.haml
+++ b/app/views/messages/_chat_form.html.haml
@@ -1,5 +1,5 @@
 .chat_form
-  = form_for [@group, @message], html: { class: "chat_form__message" } do |f|
+  = form_for [@group, @message], html: { class: "chat_form__message", id: "new_message" } do |f|
     .chat_form__message__inputbox
       = f.text_field :body, class: 'chat_form__message__inputbox__text', placeholder: "type a message"
       = f.label :image, class: 'chat_form__message__inputbox__image' do

--- a/app/views/messages/_chat_message.html.haml
+++ b/app/views/messages/_chat_message.html.haml
@@ -8,4 +8,4 @@
     - if message.body.present?
       %p
         = message.body
-    = image_tag message.image.url, class: 'chat_message__text__image' if message.image.present?
+    = image_tag message.image.url if message.image.present?

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,0 +1,4 @@
+json.body      @message.body
+json.image     @message.image
+json.user_name @message.user.name
+json.date      @message.created_at.strftime("%Y/%m/%d %H:%M")

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,4 +1,4 @@
 json.body      @message.body
-json.image     @message.image
+json.image     @message.image.url
 json.user_name @message.user.name
 json.date      @message.created_at.strftime("%Y/%m/%d %H:%M")


### PR DESCRIPTION
# What
- メッセージ投稿時
  - 非同期で送信できるようにする
  - 非同期で一覧を表示できるようにする
  - 自動で最下部にスクロールする
- メッセージ投稿後
  - フォームに入力された値及び画像をクリアする
  - ボタンを押下可能にする

- その他細かい修正
  - 投稿した画像が原寸大で表示されていたので、縮小表示するように修正

# Why
- 画面の再読み込みを行わず、メッセージを送信できるようにするため

## 画面イメージ
[![Image from Gyazo](https://i.gyazo.com/42723ca62be116adfee1172e278c23fd.gif)](https://gyazo.com/42723ca62be116adfee1172e278c23fd)