### PR TITLE
ユーザーのインクリメンタルサーチ実装

### DIFF
--- a/app/assets/javascripts/user_search.js
+++ b/app/assets/javascripts/user_search.js
@@ -26,8 +26,8 @@ $(document).on("turbolinks:load", function() {
     }
 
     function addMember(user) {
-      var user_id = user.attr("data-user-id");
-      var user_name = user.attr("data-user-name");
+      var user_id = user.data("user-id");
+      var user_name = user.data("user-name");
       var html = `<div class='chat-group-user clearfix'>
                   <input name='group[user_ids][]' type='hidden' value='${user_id}'>
                     <p class='chat-group-user__name'>

--- a/app/assets/javascripts/user_search.js
+++ b/app/assets/javascripts/user_search.js
@@ -1,10 +1,11 @@
-$(function() {
-  var userList = $("#user-search-result"); // 検索結果のユーザーリスト
-  var memberList = $("#chat-group-users"); // チャットメンバーのリスト
+$(document).on("turbolinks:load", function() {
+  $(function() {
+    var userList = $("#user-search-result"); // 検索結果のユーザーリスト
+    var memberList = $("#chat-group-users"); // チャットメンバーのリスト
 
-  // 検索結果のユーザーリストを作成
-  function appendUser(user) {
-    var html = `<div class="chat-group-user clearfix">
+    // 検索結果のユーザーリストを作成
+    function appendUser(user) {
+      var html = `<div class="chat-group-user clearfix">
                   <p class="chat-group-user__name">
                     ${user.name}
                   </p>
@@ -13,23 +14,23 @@ $(function() {
                     追加
                   </div>
                 </div>`;
-    $(userList).append(html);
-  }
+      $(userList).append(html);
+    }
 
-  function appendErrUser() {
-    var html = `<div id="chat-group-user" class="clearfix">
+    function appendErrUser() {
+      var html = `<div id="chat-group-user" class="clearfix">
                   <p class="chat-group-user">
                     一致するユーザーが見つかりません
                   </p>
                 </div>`;
-    $(userList).append(html);
-  }
+      $(userList).append(html);
+    }
 
-  // チャットメンバーのリストを作成
-  function addMember(user) {
-    var user_id = user.attr("data-user-id");
-    var user_name = user.attr("data-user-name");
-    var html = `<div class='chat-group-user clearfix'>
+    // チャットメンバーのリストを作成
+    function addMember(user) {
+      var user_id = user.attr("data-user-id");
+      var user_name = user.attr("data-user-name");
+      var html = `<div class='chat-group-user clearfix'>
                   <input name='group[user_ids][]' type='hidden' value='${user_id}'>
                     <p class='chat-group-user__name'>
                       ${user_name}
@@ -38,46 +39,47 @@ $(function() {
                       削除
                     </div>
               </div>`;
-    $(memberList).append(html);
-  }
+      $(memberList).append(html);
+    }
 
-  $("#user-search-field").keyup(function() {
-    var input = $("#user-search-field").val();
+    $("#user-search-field").keyup(function() {
+      var input = $("#user-search-field").val();
 
-    $.ajax({
-      type: "GET",
-      url: "/users",
-      data: { keyword: input },
-      dataType: "json"
-    })
-      .done(function(users) {
-        $(userList).empty(); // 検索前にリストを初期化
-        if (users.length !== 0 && input.length !== 0) {
-          // 検索結果あり＆入力あり
-          users.forEach(function(user) {
-            appendUser(user);
-          });
-        } else {
-          appendErrUser();
-        }
+      $.ajax({
+        type: "GET",
+        url: "/users",
+        data: { keyword: input },
+        dataType: "json"
       })
-      .fail(function() {
-        appendErrUser();
-        alert("ユーザー検索に失敗しました");
-      });
-  });
+        .done(function(users) {
+          $(userList).empty(); // 検索前にリストを初期化
+          if (users.length !== 0 && input.length !== 0) {
+            // 検索結果あり＆入力あり
+            users.forEach(function(user) {
+              appendUser(user);
+            });
+          } else {
+            appendErrUser();
+          }
+        })
+        .fail(function() {
+          appendErrUser();
+          alert("ユーザー検索に失敗しました");
+        });
+    });
 
-  // 追加ボタンを押したユーザーを、メンバーリストに追加＆検索結果リストから削除
-  $(userList).on("click", ".user-search-add", function() {
-    addMember($(this));
-    $(this)
-      .parent(".chat-group-user")
-      .remove();
-  });
+    // 追加ボタンを押したユーザーを、メンバーリストに追加＆検索結果リストから削除
+    $(userList).on("click", ".user-search-add", function() {
+      addMember($(this));
+      $(this)
+        .parent(".chat-group-user")
+        .remove();
+    });
 
-  $(memberList).on("click", ".user-search-remove", function() {
-    $(this)
-      .parent(".chat-group-user")
-      .remove();
+    $(memberList).on("click", ".user-search-remove", function() {
+      $(this)
+        .parent(".chat-group-user")
+        .remove();
+    });
   });
 });

--- a/app/assets/javascripts/user_search.js
+++ b/app/assets/javascripts/user_search.js
@@ -2,6 +2,7 @@ $(function() {
   var userList = $("#user-search-result"); // 検索結果のユーザーリスト
   var memberList = $("#chat-group-users"); // チャットメンバーのリスト
 
+  // 検索結果のユーザーリストを作成
   function appendUser(user) {
     var html = `<div class="chat-group-user clearfix">
                   <p class="chat-group-user__name">
@@ -24,6 +25,7 @@ $(function() {
     $(userList).append(html);
   }
 
+  // チャットメンバーのリストを作成
   function addMember(user) {
     var user_id = user.attr("data-user-id");
     var user_name = user.attr("data-user-name");
@@ -74,6 +76,8 @@ $(function() {
   });
 
   $(memberList).on("click", ".user-search-remove", function() {
-    window.alert("削除ボタン");
+    $(this)
+      .parent(".chat-group-user")
+      .remove();
   });
 });

--- a/app/assets/javascripts/user_search.js
+++ b/app/assets/javascripts/user_search.js
@@ -45,6 +45,7 @@ $(function() {
       })
       .fail(function() {
         appendErrUser();
+        alert("ユーザー検索に失敗しました");
       });
   });
 });

--- a/app/assets/javascripts/user_search.js
+++ b/app/assets/javascripts/user_search.js
@@ -44,7 +44,6 @@ $(document).on("turbolinks:load", function() {
 
     $("#user-search-field").keyup(function() {
       var input = $("#user-search-field").val();
-
       $.ajax({
         type: "GET",
         url: "/users",

--- a/app/assets/javascripts/user_search.js
+++ b/app/assets/javascripts/user_search.js
@@ -34,9 +34,9 @@ $(function() {
                     <p class='chat-group-user__name'>
                       ${user_name}
                     </p>
-                  <div class='user-search-remove chat-group-user__btn chat-group-user__btn--remove js-remove-btn'>
-                    削除
-                  </div>
+                    <div class='user-search-remove chat-group-user__btn chat-group-user__btn--remove js-remove-btn'>
+                      削除
+                    </div>
               </div>`;
     $(memberList).append(html);
   }

--- a/app/assets/javascripts/user_search.js
+++ b/app/assets/javascripts/user_search.js
@@ -1,5 +1,6 @@
 $(function() {
-  var userList = $("#user-search-result");
+  var userList = $("#user-search-result"); // 検索結果のユーザーリスト
+  var memberList = $("#chat-group-users"); // チャットメンバーのリスト
 
   function appendUser(user) {
     var html = `<div class="chat-group-user clearfix">
@@ -23,6 +24,21 @@ $(function() {
     $(userList).append(html);
   }
 
+  function addMember(user) {
+    var user_id = user.attr("data-user-id");
+    var user_name = user.attr("data-user-name");
+    var html = `<div class='chat-group-user clearfix'>
+                  <input name='group[user_ids][]' type='hidden' value='${user_id}'>
+                    <p class='chat-group-user__name'>
+                      ${user_name}
+                    </p>
+                  <div class='user-search-remove chat-group-user__btn chat-group-user__btn--remove js-remove-btn'>
+                    削除
+                  </div>
+              </div>`;
+    $(memberList).append(html);
+  }
+
   $("#user-search-field").keyup(function() {
     var input = $("#user-search-field").val();
 
@@ -38,6 +54,9 @@ $(function() {
           // 検索結果あり＆入力あり
           users.forEach(function(user) {
             appendUser(user);
+            // $(this)
+            //   .parent(".chat-group-user")
+            //   .remove();
           });
         } else {
           appendErrUser();
@@ -47,5 +66,17 @@ $(function() {
         appendErrUser();
         alert("ユーザー検索に失敗しました");
       });
+  });
+
+  // 追加ボタンを押したユーザーを、メンバーリストに追加＆検索結果リストから削除
+  $(userList).on("click", ".user-search-add", function() {
+    addMember($(this));
+    $(this)
+      .parent(".chat-group-user")
+      .remove();
+  });
+
+  $(memberList).on("click", ".user-search-remove", function() {
+    window.alert("削除ボタン");
   });
 });

--- a/app/assets/javascripts/user_search.js
+++ b/app/assets/javascripts/user_search.js
@@ -1,0 +1,50 @@
+$(function() {
+  var userList = $("#user-search-result");
+
+  function appendUser(user) {
+    var html = `<div class="chat-group-user clearfix">
+                  <p class="chat-group-user__name">
+                    ${user.name}
+                  </p>
+                  <div class="user-search-add chat-group-user__btn chat-group-user__btn--add"
+                  data-user-id="${user.id}" data-user-name="${user.name}">
+                    追加
+                  </div>
+                </div>`;
+    $(userList).append(html);
+  }
+
+  function appendErrUser() {
+    var html = `<div id="chat-group-user" class="clearfix">
+                  <p class="chat-group-user">
+                    一致するユーザーが見つかりません
+                  </p>
+                </div>`;
+    $(userList).append(html);
+  }
+
+  $("#user-search-field").keyup(function() {
+    var input = $("#user-search-field").val();
+
+    $.ajax({
+      type: "GET",
+      url: "/users",
+      data: { keyword: input },
+      dataType: "json"
+    })
+      .done(function(users) {
+        $(userList).empty(); // 検索前にリストを初期化
+        if (users.length !== 0 && input.length !== 0) {
+          // 検索結果あり＆入力あり
+          users.forEach(function(user) {
+            appendUser(user);
+          });
+        } else {
+          appendErrUser();
+        }
+      })
+      .fail(function() {
+        appendErrUser();
+      });
+  });
+});

--- a/app/assets/javascripts/user_search.js
+++ b/app/assets/javascripts/user_search.js
@@ -3,7 +3,6 @@ $(document).on("turbolinks:load", function() {
     var userList = $("#user-search-result"); // 検索結果のユーザーリスト
     var memberList = $("#chat-group-users"); // チャットメンバーのリスト
 
-    // 検索結果のユーザーリストを作成
     function appendUser(user) {
       var html = `<div class="chat-group-user clearfix">
                   <p class="chat-group-user__name">
@@ -26,7 +25,6 @@ $(document).on("turbolinks:load", function() {
       $(userList).append(html);
     }
 
-    // チャットメンバーのリストを作成
     function addMember(user) {
       var user_id = user.attr("data-user-id");
       var user_name = user.attr("data-user-name");
@@ -53,7 +51,6 @@ $(document).on("turbolinks:load", function() {
         .done(function(users) {
           $(userList).empty(); // 検索前にリストを初期化
           if (users.length !== 0 && input.length !== 0) {
-            // 検索結果あり＆入力あり
             users.forEach(function(user) {
               appendUser(user);
             });
@@ -67,7 +64,6 @@ $(document).on("turbolinks:load", function() {
         });
     });
 
-    // 追加ボタンを押したユーザーを、メンバーリストに追加＆検索結果リストから削除
     $(userList).on("click", ".user-search-add", function() {
       addMember($(this));
       $(this)

--- a/app/assets/javascripts/user_search.js
+++ b/app/assets/javascripts/user_search.js
@@ -54,9 +54,6 @@ $(function() {
           // 検索結果あり＆入力あり
           users.forEach(function(user) {
             appendUser(user);
-            // $(this)
-            //   .parent(".chat-group-user")
-            //   .remove();
           });
         } else {
           appendErrUser();

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -31,7 +31,9 @@ class GroupsController < ApplicationController
   private
   def group_params
     # user_idの値に配列を渡す
-    params.require(:group).permit(:name, { :user_ids => [] })
+    user_ids = params[:group]["user_ids"]
+    user_ids << current_user.id.to_s # ログイン中のユーザーのidは送られてこないため、個別に追加する
+    params.require(:group).permit(:name, { user_ids: [] })
   end
 
   def set_group

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,12 @@
 class UsersController < ApplicationController
+  def index
+    @users = User.where('name LIKE(?)', "%#{params[:keyword]}%").order("name ASC")
+    respond_to do |format|
+      format.html
+      format.json
+    end
+  end
+
   def edit
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,8 +1,7 @@
 class UsersController < ApplicationController
   def index
-    @users = User.where('name LIKE(?)', "%#{params[:keyword]}%").not(id: current_user.id)
+    @users = User.where('name LIKE(?)', "%#{params[:keyword]}%").where.not(id: current_user.id)
     respond_to do |format|
-      format.html
       format.json
     end
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
   def index
-    @users = User.where('name LIKE(?)', "%#{params[:keyword]}%").where.not(id: current_user.id)
+    @users = User.where('name LIKE(?) && id != (?)', "%#{params[:keyword]}%", current_user.id)
     respond_to do |format|
       format.json
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
   def index
-    @users = User.where('name LIKE(?)', "%#{params[:keyword]}%")
+    @users = User.where('name LIKE(?)', "%#{params[:keyword]}%").not(id: current_user.id)
     respond_to do |format|
       format.html
       format.json

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
   def index
-    @users = User.where('name LIKE(?)', "%#{params[:keyword]}%").order("name ASC")
+    @users = User.where('name LIKE(?)', "%#{params[:keyword]}%")
     respond_to do |format|
       format.html
       format.json

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -47,9 +47,10 @@
       %label.chat-group-form__label{for: "chat_group_チャットメンバー"} チャットメンバー
     .chat-group-form__field--right
       -# = f.collection_check_boxes :user_ids, User.all, :id, :name
-      .chat-group-user.clearfix
-        %p.chat-group-user__name
-          = current_user.name
+      #chat-group-users
+        .chat-group-user.clearfix
+          %p.chat-group-user__name
+            = current_user.name
 
       / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
       / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -8,27 +8,17 @@
 
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
-      = f.label :グループ名, class: 'chat-group-form__label'
+      = f.label :name, 'グループ名', class: 'chat-group-form__label'
     .chat-group-form__field--right
       = f.text_field :name, id: 'chat_group_name', class: 'chat-group-form__input', placeholder: 'グループ名を入力してください'
 
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
-      = f.label :チャットメンバーを追加, class: "chat-group-form__label"
-
+      = f.label :users, 'チャットメンバーを追加', class: "chat-group-form__label"
     .chat-group-form__field--right
       .chat-group-form__search.clearfix
-        = f.text_field :id, class: 'chat-group-form__input', id: 'user-search-field', placeholder: '追加したいユーザー名を入力してください', value: ""
+        %input#user-search-field.chat-group-form__input{ placeholder: '追加したいユーザー名を入力してください' }
       #user-search-result
-
-      -# %input { name: 'chat_group[user_ids][]', type: 'hidden' value: '22' }
-      -# %p.chat-group-user__name seo_kyohei
-
-      -# #user-search-result
-      -#   #chat-group-user
-      -#     #chat-group-user-22.chat-group-user.clearfix
-      -#       %p.chat-group-user
-      -#         野村
 
     / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
     /
@@ -54,7 +44,7 @@
         - group.users.each do |user|
           - unless current_user.id == user.id
             .chat-group-user.clearfix
-              %input{ name: 'group[user_ids][]', type: 'hidden', value: '${user_id}' }
+              %input{ name: 'group[user_ids][]', type: 'hidden', value: user.id }
                 %p.chat-group-user__name
                   = user.name
                 .user-search-remove.chat-group-user__btn.chat-group-user__btn--remove.js-remove-btn 
@@ -73,4 +63,4 @@
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
     .chat-group-form__field--right
-      %input.chat-group-form__action-btn{"data-disable-with": "Save", name: "commit", type: "submit", value: "Save"}/
+      %input.chat-group-form__action-btn{"data-disable-with": "Save", name: "commit", type: "submit", value: "Save"}

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -10,7 +10,7 @@
     .chat-group-form__field--left
       = f.label :グループ名, class: 'chat-group-form__label'
     .chat-group-form__field--right
-      = f.text_field :name, id: 'chat_group_name', class: 'chat-group-form__input',   placeholder: 'グループ名を入力してください'
+      = f.text_field :name, id: 'chat_group_name', class: 'chat-group-form__input', placeholder: 'グループ名を入力してください'
 
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
@@ -18,7 +18,7 @@
 
     .chat-group-form__field--right
       .chat-group-form__search.clearfix
-        = f.text_field :id, class: 'chat-group-form__input', id: 'user-search-field', placeholder: '追加したいユーザー名を入力してください'
+        = f.text_field :id, class: 'chat-group-form__input', id: 'user-search-field', placeholder: '追加したいユーザー名を入力してください', value: ""
       #user-search-result
 
       -# %input { name: 'chat_group[user_ids][]', type: 'hidden' value: '22' }
@@ -46,11 +46,20 @@
     .chat-group-form__field--left
       %label.chat-group-form__label{for: "chat_group_チャットメンバー"} チャットメンバー
     .chat-group-form__field--right
-      -# = f.collection_check_boxes :user_ids, User.all, :id, :name
       #chat-group-users
         .chat-group-user.clearfix
           %p.chat-group-user__name
             = current_user.name
+
+        - group.users.each do |user|
+          - unless current_user.id == user.id
+            .chat-group-user.clearfix
+              %input{ name: 'group[user_ids][]', type: 'hidden', value: '${user_id}' }
+                %p.chat-group-user__name
+                  = user.name
+                .user-search-remove.chat-group-user__btn.chat-group-user__btn--remove.js-remove-btn 
+                  削除
+
 
       / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
       / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -42,12 +42,14 @@
       <div id='user-search-result'></div>
       </div>
 
-  -# .chat-group-form__field.clearfix
-  -#   .chat-group-form__field--left
-  -#     %label.chat-group-form__label{for: "chat_group_チャットメンバー"} チャットメンバー
-  -#   .chat-group-form__field--right
-  -#     = f.collection_check_boxes :user_ids, User.all, :id, :name
-
+  .chat-group-form__field.clearfix
+    .chat-group-form__field--left
+      %label.chat-group-form__label{for: "chat_group_チャットメンバー"} チャットメンバー
+    .chat-group-form__field--right
+      -# = f.collection_check_boxes :user_ids, User.all, :id, :name
+      .chat-group-user.clearfix
+        %p.chat-group-user__name
+          = current_user.name
 
       / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
       / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -11,7 +11,25 @@
       = f.label :グループ名, class: 'chat-group-form__label'
     .chat-group-form__field--right
       = f.text_field :name, id: 'chat_group_name', class: 'chat-group-form__input',   placeholder: 'グループ名を入力してください'
+
   .chat-group-form__field.clearfix
+    .chat-group-form__field--left
+      = f.label :チャットメンバーを追加, class: "chat-group-form__label"
+
+    .chat-group-form__field--right
+      .chat-group-form__search.clearfix
+        = f.text_field :id, class: 'chat-group-form__input', id: 'user-search-field', placeholder: '追加したいユーザー名を入力してください'
+      #user-search-result
+
+      -# %input { name: 'chat_group[user_ids][]', type: 'hidden' value: '22' }
+      -# %p.chat-group-user__name seo_kyohei
+
+      -# #user-search-result
+      -#   #chat-group-user
+      -#     #chat-group-user-22.chat-group-user.clearfix
+      -#       %p.chat-group-user
+      -#         野村
+
     / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
     /
       <div class='chat-group-form__field--left'>
@@ -23,11 +41,14 @@
       </div>
       <div id='user-search-result'></div>
       </div>
-  .chat-group-form__field.clearfix
-    .chat-group-form__field--left
-      %label.chat-group-form__label{for: "chat_group_チャットメンバー"} チャットメンバー
-    .chat-group-form__field--right
-      = f.collection_check_boxes :user_ids, User.all, :id, :name
+
+  -# .chat-group-form__field.clearfix
+  -#   .chat-group-form__field--left
+  -#     %label.chat-group-form__label{for: "chat_group_チャットメンバー"} チャットメンバー
+  -#   .chat-group-form__field--right
+  -#     = f.collection_check_boxes :user_ids, User.all, :id, :name
+
+
       / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
       / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
       /

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -17,7 +17,7 @@
       = f.label :users, 'チャットメンバーを追加', class: "chat-group-form__label"
     .chat-group-form__field--right
       .chat-group-form__search.clearfix
-        %input#user-search-field.chat-group-form__input{ placeholder: '追加したいユーザー名を入力してください' }
+        %input#user-search-field.chat-group-form__input{ placeholder: '追加したいユーザー名を入力してください', autocomplete: 'off' }
       #user-search-result
 
     / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -20,18 +20,6 @@
         %input#user-search-field.chat-group-form__input{ placeholder: '追加したいユーザー名を入力してください', autocomplete: 'off' }
       #user-search-result
 
-    / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
-    /
-      <div class='chat-group-form__field--left'>
-      <label class="chat-group-form__label" for="chat_group_チャットメンバーを追加">チャットメンバーを追加</label>
-      </div>
-      <div class='chat-group-form__field--right'>
-      <div class='chat-group-form__search clearfix'>
-      <input class='chat-group-form__input' id='user-search-field' placeholder='追加したいユーザー名を入力してください' type='text'>
-      </div>
-      <div id='user-search-result'></div>
-      </div>
-
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
       %label.chat-group-form__label{for: "chat_group_チャットメンバー"} チャットメンバー
@@ -50,16 +38,6 @@
                 .user-search-remove.chat-group-user__btn.chat-group-user__btn--remove.js-remove-btn 
                   削除
 
-
-      / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
-      / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
-      /
-        <div id='chat-group-users'>
-        <div class='chat-group-user clearfix' id='chat-group-user-22'>
-        <input name='chat_group[user_ids][]' type='hidden' value='22'>
-        <p class='chat-group-user__name'>seo_kyohei</p>
-        </div>
-        </div>
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
     .chat-group-form__field--right

--- a/app/views/messages/_chat_header.html.haml
+++ b/app/views/messages/_chat_header.html.haml
@@ -9,5 +9,5 @@
           = user.name
 
   .chat_header__right
-    = link_to edit_group_path(1) do
+    = link_to edit_group_path(group) do
       %button.chat_header__right__editButton Edit

--- a/app/views/users/index.json.jbuilder
+++ b/app/views/users/index.json.jbuilder
@@ -1,0 +1,4 @@
+json.array! @users do |user|
+  json.id user.id
+  json.name user.name
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users
-  resources  :users,  only: [:edit, :update]
+  resources  :users,  only: [:index, :edit, :update]
   resources  :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
   end


### PR DESCRIPTION
# What
- グループ作成または編集時に、招待するユーザーを名前で検索できる機能を追加
  - ユーザー名横の「追加」ボタン押下時、チャットメンバー欄に追加される
  - ユーザー名横の「削除」ボタン押下時、チャットメンバー欄から削除される
  - ただし、現在ログイン中のユーザー(自分)はメンバーから削除不可

# Why
- ユーザーが増加しても、名前で検索できることによって目的の人を探しやすくなる。
- どのユーザーをグループに招待しているのか、視覚的に分かりやすくなる。
- 誤って自分をグループから削除してしまうことがなくなる。
- 誤って招待してしまったユーザーを削除することができるため、トラブル防止になる。


## 画面イメージ
[![Image from Gyazo](https://i.gyazo.com/74586e71c6bd7de591ac270fb316175f.gif)](https://gyazo.com/74586e71c6bd7de591ac270fb316175f)