### PR TITLE
メッセージの自動更新機能の実装

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -66,6 +66,14 @@ $(document).on("turbolinks:load", function() {
       })
         .done(function(messages) {
           console.log("success");
+          var insertHTML = "";
+          var target = ".chat_messages";
+
+          messages.forEach(function(message) {
+            insertHtml = buildHTML(message);
+            $(target).append(html);
+            scrollBottom(target);
+          });
         })
         .fail(function() {
           console.log("error");

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -73,7 +73,7 @@ $(document).on("turbolinks:load", function() {
 
             messages.forEach(function(message) {
               insertHtml = buildHTML(message);
-              $(target).append(html);
+              $(target).append(insertHtml);
               scrollBottom(target);
             });
           })

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,5 +1,23 @@
 $(document).on("turbolinks:load", function() {
   $(function() {
+    var reloadMessages = function() {
+      var last_message = $(".chat_message").last(); // 画面に表示されている、最新のメッセージを取得
+      var last_message_id = last_message.data("message-id"); // 最新メッセージのidを取得
+
+      $.ajax({
+        url: "***",
+        type: "GET",
+        dataType: "json",
+        data: { id: last_message_id }
+      })
+        .done(function(messages) {
+          console.log("success");
+        })
+        .fail(function() {
+          console.log("error");
+        });
+    };
+
     function buildHTML(message) {
       var image = message.image ? `<img src= ${message.image}>` : "";
       var html = `<div class="chat_message">

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -79,5 +79,6 @@ $(document).on("turbolinks:load", function() {
           console.log("error");
         });
     };
+    setInterval(reloadMessages, 5000);
   });
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -5,7 +5,7 @@ $(document).on("turbolinks:load", function() {
       var last_message_id = last_message.data("message-id"); // 最新メッセージのidを取得
 
       $.ajax({
-        url: "***",
+        url: "api/messages",
         type: "GET",
         dataType: "json",
         data: { id: last_message_id }

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -55,29 +55,32 @@ $(document).on("turbolinks:load", function() {
     });
 
     var reloadMessages = function() {
-      var last_message = $(".chat_message").last(); // 画面に表示されている、最新のメッセージを取得
-      var last_message_id = last_message.data("message-id"); // 最新メッセージのidを取得
+      // メッセージのページでのみ自動更新する
+      if (window.location.href.match(/\/groups\/\d+\/messages/)) {
+        var last_message = $(".chat_message").last(); // 画面に表示されている、最新のメッセージを取得
+        var last_message_id = last_message.data("message-id"); // 最新メッセージのidを取得
 
-      $.ajax({
-        url: "api/messages",
-        type: "GET",
-        dataType: "json",
-        data: { id: last_message_id }
-      })
-        .done(function(messages) {
-          console.log("success");
-          var insertHTML = "";
-          var target = ".chat_messages";
-
-          messages.forEach(function(message) {
-            insertHtml = buildHTML(message);
-            $(target).append(html);
-            scrollBottom(target);
-          });
+        $.ajax({
+          url: "api/messages",
+          type: "GET",
+          dataType: "json",
+          data: { id: last_message_id }
         })
-        .fail(function() {
-          alert("自動更新に失敗しました。");
-        });
+          .done(function(messages) {
+            console.log("success");
+            var insertHTML = "";
+            var target = ".chat_messages";
+
+            messages.forEach(function(message) {
+              insertHtml = buildHTML(message);
+              $(target).append(html);
+              scrollBottom(target);
+            });
+          })
+          .fail(function() {
+            alert("自動更新に失敗しました。");
+          });
+      }
     };
     setInterval(reloadMessages, 5000);
   });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -76,7 +76,7 @@ $(document).on("turbolinks:load", function() {
           });
         })
         .fail(function() {
-          console.log("error");
+          alert("自動更新に失敗しました。");
         });
     };
     setInterval(reloadMessages, 5000);

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -23,7 +23,7 @@ $(document).on("turbolinks:load", function() {
 
     function scrollBottom(target) {
       var scrollHeight = $(target)[0].scrollHeight;
-      $(target).animate({ scrollTop: scrollHeight }, 1000);
+      $(target).animate({ scrollTop: scrollHeight }, "fast");
     }
 
     $("#new_message").submit(function(e) {
@@ -67,7 +67,6 @@ $(document).on("turbolinks:load", function() {
           data: { id: last_message_id }
         })
           .done(function(messages) {
-            console.log("success");
             var insertHTML = "";
             var target = ".chat_messages";
 

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -2,7 +2,7 @@ $(document).on("turbolinks:load", function() {
   $(function() {
     function buildHTML(message) {
       var image = message.image ? `<img src= ${message.image}>` : "";
-      var html = `<div class="chat_message">
+      var html = `<div class="chat_message" data-message-id="${message.id}">
                   <div class="chat_message__header">
                     <p class="chat_message__header__name">
                       ${message.user_name}

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,23 +1,5 @@
 $(document).on("turbolinks:load", function() {
   $(function() {
-    var reloadMessages = function() {
-      var last_message = $(".chat_message").last(); // 画面に表示されている、最新のメッセージを取得
-      var last_message_id = last_message.data("message-id"); // 最新メッセージのidを取得
-
-      $.ajax({
-        url: "api/messages",
-        type: "GET",
-        dataType: "json",
-        data: { id: last_message_id }
-      })
-        .done(function(messages) {
-          console.log("success");
-        })
-        .fail(function() {
-          console.log("error");
-        });
-    };
-
     function buildHTML(message) {
       var image = message.image ? `<img src= ${message.image}>` : "";
       var html = `<div class="chat_message">
@@ -71,5 +53,23 @@ $(document).on("turbolinks:load", function() {
           $(".chat_form__message__button").prop("disabled", false); // ボタンを押下可能にする
         });
     });
+
+    var reloadMessages = function() {
+      var last_message = $(".chat_message").last(); // 画面に表示されている、最新のメッセージを取得
+      var last_message_id = last_message.data("message-id"); // 最新メッセージのidを取得
+
+      $.ajax({
+        url: "api/messages",
+        type: "GET",
+        dataType: "json",
+        data: { id: last_message_id }
+      })
+        .done(function(messages) {
+          console.log("success");
+        })
+        .fail(function() {
+          console.log("error");
+        });
+    };
   });
 });

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,4 @@
+class Api::MessagesController < ApplicationController
+  def index
+  end
+end

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,10 +1,10 @@
 class Api::MessagesController < ApplicationController
   def index
     @group = Group.find(params[:group_id])
-    @messages = @group.messages.includes(:user)
+    @messages = @group.messages.includes(:user).where('id > ?', params[:id])
     respond_to do |format|
       format.html
-      format.json{ @new_messages = Message.where('id > ?', params[:id]) }
+      format.json
     end
   end
 end

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,4 +1,10 @@
 class Api::MessagesController < ApplicationController
   def index
+    @group = Group.find(params[:group_id])
+    @messages = @group.messages.includes(:user)
+    respond_to do |format|
+      format.html
+      format.json{ @new_messages = Message.where('id > ?', params[:id]) }
+    end
   end
 end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -11,9 +11,9 @@ class MessagesController < ApplicationController
     @message = @group.messages.new(message_params)
     if @message.save
       respond_to do |format|
-       format.html
-       format.json
-     end
+        format.html
+        format.json
+      end
     else
       flash.now[:alert] = 'メッセージを入力してください。'
       render :index

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.body      message.body
+  json.image     message.image.url
+  json.user_name message.user.name
+  json.date      message.created_at.strftime("%Y/%m/%d %H:%M")
+  json.id        message.id
+end

--- a/app/views/messages/_chat_message.html.haml
+++ b/app/views/messages/_chat_message.html.haml
@@ -1,4 +1,4 @@
-.chat_message
+.chat_message{ "data-message-id": "#{message.id}"}
   .chat_message__header
     %p.chat_message__header__name
       = message.user.name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -2,3 +2,4 @@ json.body      @message.body
 json.image     @message.image.url
 json.user_name @message.user.name
 json.date      @message.created_at.strftime("%Y/%m/%d %H:%M")
+json.id        @message.id

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -2,4 +2,3 @@ json.body      @message.body
 json.image     @message.image.url
 json.user_name @message.user.name
 json.date      @message.created_at.strftime("%Y/%m/%d %H:%M")
-json.id        @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,10 @@ Rails.application.routes.draw do
   resources  :users,  only: [:index, :edit, :update]
   resources  :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 
   root 'groups#index'


### PR DESCRIPTION
# What
- 5秒おきに、グループ内で新規メッセージが投稿されていないか確認する
  - 新規投稿があれば、再読み込みを行わなくても画面にメッセージを反映させる

# Why
- 画面の再読み込みを行わなくても、新規メッセージを確認できるようにする

# 画面イメージ
[![Image from Gyazo](https://i.gyazo.com/9281132162b8cba0d96c05c477b5d4ec.gif)](https://gyazo.com/9281132162b8cba0d96c05c477b5d4ec)